### PR TITLE
database performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
  "value-bag",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "decklist"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decklist"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Seth <bajablastoise@protonmail.com>"]
 license = "Unlicense"

--- a/src/app.rs
+++ b/src/app.rs
@@ -465,7 +465,7 @@ impl App {
             let map = self.dc.database_cards.clone();
             let path = self.dc.database_path.clone();
             let debug_channel = self.debug_channel.0.clone();
-            if self.load_done && !self.short_started {
+            if self.load_done && !self.short_started && !self.short_done {
                 // TODO: reset this when loading a new database
                 self.short_started = true;
                 // TODO: eventually make another condition for when the short database has been

--- a/src/app.rs
+++ b/src/app.rs
@@ -443,9 +443,10 @@ impl App {
                 self.dc.database_status = format!("Loading {} ...", self.dc.filename);
                 let database_channel = self.database_channel.0.clone();
                 let dc_clone = self.dc.clone();
+                let currency = self.config.currency.clone();
                 self.database_counter += 1;
                 thread::spawn(move || {
-                    let database_results = task::block_on(load_database_file(dc_clone));
+                    let database_results = task::block_on(load_database_file(dc_clone, currency));
                     if let Ok(()) = database_channel.send(database_results) {};
                 });
                 self.dc.ready_load = false;

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use crate::{
     database::scryfall::{get_min_price, match_card, min_price_fmt, serialize_database},
     startup::{
         config_check, database_check, database_management, directory_check, dl_scryfall_latest,
-        load_database_file, ConfigCheck, DatabaseCheck, DirectoryCheck,
+        load_database_file, ConfigCheck, DatabaseCheck, DatabaseType, DirectoryCheck,
     },
 };
 use arboard::Clipboard;
@@ -462,7 +462,14 @@ impl App {
             // if a Scryfall database is loaded and the hashmap is done, serialize and save as a
             // custom database JSON with a single copy of each card with the lowest price so the
             // hashmap doesn't have to be filtered each time the program starts
-            if self.load_done && !self.short_started && !self.short_done {
+            // only do it if loading a Scryfall JSON
+            if self.load_done
+                && !self.short_started
+                && !self.short_done
+                && self.dc.db_type == DatabaseType::Scryfall
+                && self.dc.database_cards.len() > 10
+            // don't overwrite database if loading fails
+            {
                 let map = self.dc.database_cards.clone();
                 let path = self.dc.database_path.clone();
                 // TODO: reset this when loading a new database

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,6 +77,7 @@ pub struct App {
     pub dl_done: bool,
     pub load_started: bool,
     pub load_done: bool,
+    pub short_done: bool, // shorter JSON w/ single copy and lowest price
     pub os: SupportedOS,
     pub directory_exist: bool,
     pub data_directory_exist: bool,
@@ -184,6 +185,7 @@ impl Default for App {
             dl_done: false,
             load_started: false,
             load_done: false,
+            short_done: false,
             os: SupportedOS::default(),
             directory_exist: false,
             data_directory_exist: false,
@@ -447,6 +449,14 @@ impl App {
                     self.database_ok = !self.dc.database_cards.is_empty();
                     self.redraw = true;
                 }
+            }
+            // if a Scryfall database is loaded and the hashmap is done, serialize and save as a
+            // custom database JSON with a single copy of each card with the lowest price so the
+            // hashmap doesn't have to be filtered each time the program starts
+            if self.load_done {
+                // TODO: eventually make another condition for when the short database has been
+                // loaded instead of a Scryfall file
+                //
             }
             if self.loading_collection {
                 if let Ok(msg) = self.collection_channel.1.try_recv() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -464,7 +464,6 @@ impl App {
             // hashmap doesn't have to be filtered each time the program starts
             let map = self.dc.database_cards.clone();
             let path = self.dc.database_path.clone();
-            let debug_channel = self.debug_channel.0.clone();
             if self.load_done && !self.short_started && !self.short_done {
                 // TODO: reset this when loading a new database
                 self.short_started = true;
@@ -472,15 +471,14 @@ impl App {
                 // loaded instead of a Scryfall file
                 let short_channel = self.short_channel.0.clone();
                 self.short_counter += 1;
-                thread::spawn(move || {
-                    if let Ok(()) = debug_channel.send("Starting short thread...\n".to_string()) {};
-                    match task::block_on(serialize_database(&map, path)) {
+                thread::spawn(
+                    move || match task::block_on(serialize_database(&map, path)) {
                         Ok(()) => short_channel.send(
                             "Compact decklist database generated successfully.\n".to_string(),
                         ),
                         Err(e) => short_channel.send(e.to_string()),
-                    }
-                });
+                    },
+                );
             }
             if self.short_started && !self.short_done {
                 if let Ok(s) = self.debug_channel.1.try_recv() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -394,6 +394,7 @@ impl App {
                     self.dc.need_dl = dc.need_dl;
                     self.dc.ready_load = dc.ready_load;
                     self.dc.filename = dc.filename;
+                    self.dc.db_type = dc.db_type;
                     if dc.database_exists {
                         self.database_ok = true;
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -462,9 +462,9 @@ impl App {
             // if a Scryfall database is loaded and the hashmap is done, serialize and save as a
             // custom database JSON with a single copy of each card with the lowest price so the
             // hashmap doesn't have to be filtered each time the program starts
-            let map = self.dc.database_cards.clone();
-            let path = self.dc.database_path.clone();
             if self.load_done && !self.short_started && !self.short_done {
+                let map = self.dc.database_cards.clone();
+                let path = self.dc.database_path.clone();
                 // TODO: reset this when loading a new database
                 self.short_started = true;
                 // TODO: eventually make another condition for when the short database has been

--- a/src/database/scryfall.rs
+++ b/src/database/scryfall.rs
@@ -913,11 +913,13 @@ pub async fn serialize_database(
     path: PathBuf,
 ) -> Result<(), Box<dyn Error>> {
     let json_string = serde_json::to_string_pretty(map)?;
-    let mut file_path = path.join(PathBuf::from("decklist_"));
-    let date_str = Local::now().to_string();
-    file_path.push(PathBuf::from(date_str));
-    file_path.push(".json");
-    let mut file = File::create(path)?;
+    let mut file_path_str = String::from("decklist_");
+    let date = Local::now();
+    let date_str = format!("{}", date.format("%Y%m%d"));
+    file_path_str.push_str(&date_str);
+    file_path_str.push_str(".json");
+    let file_path = path.join(PathBuf::from(file_path_str));
+    let mut file = File::create(file_path)?;
     file.write_all(json_string.as_bytes())?;
     Ok(())
 }

--- a/src/database/scryfall.rs
+++ b/src/database/scryfall.rs
@@ -908,7 +908,7 @@ pub fn make_safe_name(name: &str, dual: bool) -> String {
 }
 
 /// saves the Scryfall database in a serial file
-pub fn serialize_database(
+pub async fn serialize_database(
     map: &HashMap<String, ScryfallCard>,
     path: PathBuf,
 ) -> Result<(), Box<dyn Error>> {

--- a/src/database/scryfall.rs
+++ b/src/database/scryfall.rs
@@ -916,6 +916,7 @@ pub async fn serialize_database(
     let mut file_path = path.join(PathBuf::from("decklist_"));
     let date_str = Local::now().to_string();
     file_path.push(PathBuf::from(date_str));
+    file_path.push(".json");
     let mut file = File::create(path)?;
     file.write_all(json_string.as_bytes())?;
     Ok(())

--- a/src/database/scryfall.rs
+++ b/src/database/scryfall.rs
@@ -841,7 +841,6 @@ pub fn read_scryfall_database(
             || card.layout == CardLayouts::ModalDualFaceCard
             || card.layout == CardLayouts::Adventure;
         let safe_name = make_safe_name(&card.name, dual);
-        // TODO: get all currencies in here
         result_map
             .entry(safe_name)
             .and_modify(|existing| {
@@ -864,7 +863,7 @@ pub fn read_scryfall_database(
                         Err(_) => {}
                     }
                 }
-                if c_price > 0.0 && c_price < e_price {
+                if c_price > 0.0 && (c_price < e_price || e_price == 0.0) {
                     *existing = card.clone();
                 }
             })

--- a/src/database/scryfall.rs
+++ b/src/database/scryfall.rs
@@ -744,6 +744,8 @@ pub enum ScryfallSetType {
     FromTheVault,
     #[serde(rename = "spellbook")]
     Spellbook,
+    #[serde(rename = "eternal")]
+    Eternal,
 }
 
 /// card rarities
@@ -823,7 +825,7 @@ pub struct ScryfallPurchase {
     pub cardhoarder: String,
 }
 
-/// reads provided JSON database file and produces a vector of ScryfallCard objects
+/// reads provided JSON database file and produces a hash map of ScryfallCard objects
 pub fn read_scryfall_database(
     path: &PathBuf,
 ) -> Result<HashMap<String, ScryfallCard>, Box<dyn Error>> {
@@ -849,6 +851,15 @@ pub fn read_scryfall_database(
             .or_insert(card.clone());
     }
     Ok(result_map)
+}
+
+/// reads custom decklist JSON file
+pub fn read_decklist_database(
+    path: &PathBuf,
+) -> Result<HashMap<String, ScryfallCard>, Box<dyn Error>> {
+    let file_text = fs::read_to_string(path)?;
+    let map: HashMap<String, ScryfallCard> = serde_json::from_str(&file_text)?;
+    Ok(map)
 }
 
 // TODO: maybe replace the manual implementations of this elsewhere?

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,9 @@ pub mod database;
 pub mod startup;
 pub mod tui;
 
+use app::App;
 use ratatui_explorer::{FileExplorer, Theme};
 use tui::core::{init, restore};
-
-use app::App;
 
 #[tokio::main]
 async fn main() -> Result<(), io::Error> {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -134,7 +134,7 @@ impl Default for DatabaseCheck {
 
 // indicates if database to be loaded is a Scryfall JSON or a decklist JSON, as they need to be
 // parsed differently
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum DatabaseType {
     Scryfall,
     Decklist,
@@ -208,6 +208,7 @@ pub async fn load_database_file(mut dc: DatabaseCheck) -> DatabaseCheck {
     let mut data_path = dc.database_path.clone();
     data_path.push(dc.filename.clone());
     // determine if loading a Scryfall or Decklist database
+    println!("{:?}", dc.db_type);
     match dc.db_type {
         DatabaseType::Decklist => match read_decklist_database(&data_path) {
             Ok(cards) => {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -14,7 +14,7 @@ use ureq::Agent;
 
 use crate::{
     config::DecklistConfig,
-    database::scryfall::{read_scryfall_database, ScryfallCard},
+    database::scryfall::{read_decklist_database, read_scryfall_database, ScryfallCard},
 };
 
 /*
@@ -114,6 +114,7 @@ pub struct DatabaseCheck {
     pub filename: String,
     pub need_dl: bool,
     pub ready_load: bool,
+    pub db_type: DatabaseType,
 }
 
 impl Default for DatabaseCheck {
@@ -126,12 +127,14 @@ impl Default for DatabaseCheck {
             filename: String::new(),
             need_dl: false,
             ready_load: false,
+            db_type: DatabaseType::Scryfall,
         }
     }
 }
 
 // indicates if database to be loaded is a Scryfall JSON or a decklist JSON, as they need to be
 // parsed differently
+#[derive(Clone)]
 pub enum DatabaseType {
     Scryfall,
     Decklist,
@@ -143,6 +146,7 @@ pub async fn database_check(data_path: PathBuf, max_age: u64) -> DatabaseCheck {
     let mut need_download = false;
     let mut ready_load = false;
     let mut database_exists = false;
+    let mut db_type = DatabaseType::Scryfall;
     let database_status;
     let database_cards = HashMap::new();
     let mut filename = String::new();
@@ -160,6 +164,7 @@ pub async fn database_check(data_path: PathBuf, max_age: u64) -> DatabaseCheck {
             database_status = format!("Recent decklist database found: {}", fname.clone());
             filename = fname;
             ready_load = true;
+            db_type = DatabaseType::Decklist;
         }
     } else if let Some((fname, date)) = find_scryfall_database(data_path.clone()) {
         let current_time: DateTime<Local> = Local::now();
@@ -193,6 +198,7 @@ pub async fn database_check(data_path: PathBuf, max_age: u64) -> DatabaseCheck {
         need_dl: need_download,
         ready_load,
         filename,
+        db_type,
     }
 }
 
@@ -201,14 +207,28 @@ pub async fn database_check(data_path: PathBuf, max_age: u64) -> DatabaseCheck {
 pub async fn load_database_file(mut dc: DatabaseCheck) -> DatabaseCheck {
     let mut data_path = dc.database_path.clone();
     data_path.push(dc.filename.clone());
-    match read_scryfall_database(&data_path) {
-        Ok(cards) => {
-            dc.database_exists = true;
-            dc.database_status = format!("Loaded cards from: {}", dc.filename);
-            dc.database_cards = cards;
-            dc.ready_load = false; // file loaded successfully, don't need to do again
+    // determine if loading a Scryfall or Decklist database
+    match dc.db_type {
+        DatabaseType::Decklist => match read_decklist_database(&data_path) {
+            Ok(cards) => {
+                dc.database_exists = true;
+                dc.database_status = format!("Loaded cards from: {}", dc.filename);
+                dc.database_cards = cards;
+                dc.ready_load = false;
+            }
+            Err(e) => dc.database_status = e.to_string(),
+        },
+        DatabaseType::Scryfall => {
+            match read_scryfall_database(&data_path) {
+                Ok(cards) => {
+                    dc.database_exists = true;
+                    dc.database_status = format!("Loaded cards from: {}", dc.filename);
+                    dc.database_cards = cards;
+                    dc.ready_load = false; // file loaded successfully, don't need to do again
+                }
+                Err(e) => dc.database_status = e.to_string(),
+            }
         }
-        Err(e) => dc.database_status = e.to_string(),
     }
     dc
 }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -208,7 +208,6 @@ pub async fn load_database_file(mut dc: DatabaseCheck) -> DatabaseCheck {
     let mut data_path = dc.database_path.clone();
     data_path.push(dc.filename.clone());
     // determine if loading a Scryfall or Decklist database
-    println!("{:?}", dc.db_type);
     match dc.db_type {
         DatabaseType::Decklist => match read_decklist_database(&data_path) {
             Ok(cards) => {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -14,7 +14,7 @@ use ureq::Agent;
 
 use crate::{
     config::DecklistConfig,
-    database::scryfall::{read_decklist_database, read_scryfall_database, ScryfallCard},
+    database::scryfall::{read_decklist_database, read_scryfall_database, PriceType, ScryfallCard},
 };
 
 /*
@@ -204,7 +204,7 @@ pub async fn database_check(data_path: PathBuf, max_age: u64) -> DatabaseCheck {
 
 /// attempts to load given database file
 /// updates status accordingly
-pub async fn load_database_file(mut dc: DatabaseCheck) -> DatabaseCheck {
+pub async fn load_database_file(mut dc: DatabaseCheck, currency: PriceType) -> DatabaseCheck {
     let mut data_path = dc.database_path.clone();
     data_path.push(dc.filename.clone());
     // determine if loading a Scryfall or Decklist database
@@ -219,7 +219,7 @@ pub async fn load_database_file(mut dc: DatabaseCheck) -> DatabaseCheck {
             Err(e) => dc.database_status = e.to_string(),
         },
         DatabaseType::Scryfall => {
-            match read_scryfall_database(&data_path) {
+            match read_scryfall_database(&data_path, currency) {
                 Ok(cards) => {
                     dc.database_exists = true;
                     dc.database_status = format!("Loaded cards from: {}", dc.filename);

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -263,7 +263,7 @@ async fn scryfall_bulk_request(
     // first request gets URI for latest data
     let resp: ScryfallResponse = scryfall_agent
         .get("https://api.scryfall.com/bulk-data/default-cards")
-        .header("User-Agent", "decklistv0.3.1")
+        .header("User-Agent", "decklistv0.5.0")
         .header("Accept", "*/*")
         .call()?
         .body_mut()
@@ -278,7 +278,7 @@ async fn scryfall_bulk_request(
     // second request downloads JSON file to user data directory
     let download_request = scryfall_agent
         .get(uri)
-        .header("User-Agent", "decklistv0.3.1")
+        .header("User-Agent", "decklistv0.5.0")
         .header("Accept", "application/file")
         .call()?
         .body_mut()

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -130,6 +130,13 @@ impl Default for DatabaseCheck {
     }
 }
 
+// indicates if database to be loaded is a Scryfall JSON or a decklist JSON, as they need to be
+// parsed differently
+pub enum DatabaseType {
+    Scryfall,
+    Decklist,
+}
+
 /// checks for existence of database file
 /// if none are found, prompt to download a new file
 pub async fn database_check(data_path: PathBuf, max_age: u64) -> DatabaseCheck {

--- a/src/tui/core.rs
+++ b/src/tui/core.rs
@@ -86,7 +86,7 @@ pub fn ui(
 
     // define main/center area for display
     let version =
-        Line::from(vec!["| Decklist v0.4.0 |".into()]).style(Style::default().cyan().bold());
+        Line::from(vec!["| Decklist v0.5.0 |".into()]).style(Style::default().cyan().bold());
     let main_block = Block::default()
         .title_bottom(version)
         .title_alignment(Alignment::Center)

--- a/src/tui/core.rs
+++ b/src/tui/core.rs
@@ -231,6 +231,11 @@ fn draw_debug_main(app: &mut App, frame: &mut Frame, chunk: Rect, main_block: Bl
             Span::from(space_padding(10)),
             Span::from(format!("{}", app.price_counter)).cyan(),
         ]),
+        Line::from(vec![
+            Span::from("Short Check: ").bold(),
+            Span::from(space_padding(10)),
+            Span::from(format!("{}", app.short_counter)).cyan(),
+        ]),
     ]);
     frame.render_widget(main_block, chunk);
     frame.render_widget(debug_text, sections[0]);


### PR DESCRIPTION
The program used to use a large database file from Scryfall to find the cheapest card prices.  Loading that database on startup and sorting down to the cheapest price for each card on every startup took a while.  Now the program creates a shorter JSON file with just the info for the cheapest printing of each card and uses that until the age limit is exceeded and is much faster on startup.